### PR TITLE
Fix console spam with newer SteamWorks SDK releases

### DIFF
--- a/module/module.cpp
+++ b/module/module.cpp
@@ -32,8 +32,6 @@ void OnPluginsLoaded()
 
 void OnSteamAPIActivated()
 {
-	g_pFunctionTable_Post->pfnStartFrame = OnStartFrame;
-
 	g_SteamTools->m_Forwards->OnSteamFullyLoaded();
 	g_SteamTools->m_Hooks->AddHooks();
 	
@@ -42,15 +40,6 @@ void OnSteamAPIActivated()
 
 void OnSteamAPIShutdown()
 {
-	g_pFunctionTable_Post->pfnStartFrame = nullptr;
-
 	g_SteamTools->m_Forwards->OnSteamShutdown();
 	g_SteamTools->m_Hooks->RemoveHooks();
-}
-
-void OnStartFrame()
-{
-	g_SteamTools->Think();
-
-	RETURN_META(MRES_IGNORED);
 }

--- a/module/msvc/module.vcxproj
+++ b/module/msvc/module.vcxproj
@@ -99,7 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_USING_V120_SDK71_;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_ITERATOR_DEBUG_LEVEL=0;_CRT_NONSTDC_NO_DEPRECATE;HAVE_STDINT_H;_DEBUG;_WINDOWS;_USRDLL;WIN32PROJECT1_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>.;..\;..\includes;..\..\public;..\..\public\sdk;..\..\public\amtl\include;..\..\public\memtools;..\..\public\open-steamworks\Open Steamworks;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;..\;..\includes;..\..\..\public;..\..\public;..\..\public\sdk;..\..\public\amtl\include;..\..\public\memtools;..\..\public\open-steamworks\Open Steamworks;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <BrowseInformation>true</BrowseInformation>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -120,7 +120,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_ITERATOR_DEBUG_LEVEL=0;_CRT_NONSTDC_NO_DEPRECATE;HAVE_STDINT_H;NDEBUG;_WINDOWS;_USRDLL;HTTP_DOWNLOAD_MANAGER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>.;..\;..\includes;..\..\public;..\..\public\sdk;..\..\public\amtl\include;..\..\public\memtools;..\..\public\open-steamworks\Open Steamworks;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;..\;..\includes;..\..\..\public;..\..\public;..\..\public\sdk;..\..\public\amtl\include;..\..\public\memtools;..\..\public\open-steamworks\Open Steamworks;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <StringPooling>true</StringPooling>
       <WholeProgramOptimization>false</WholeProgramOptimization>

--- a/module/steamtools.cpp
+++ b/module/steamtools.cpp
@@ -63,11 +63,6 @@ void SteamTools::OnAPIShutdown()
 	m_APiShutdownCallback();
 }
 
-void SteamTools::Think()
-{
-	m_GameServer->Think();
-}
-
 bool SteamTools::IsSteamToolsLoaded()
 {
 	return m_Loaded;

--- a/module/steamtools.h
+++ b/module/steamtools.h
@@ -27,7 +27,6 @@ class SteamTools
 	public:
 
 		void Init();
-		void Think();
 		bool IsSteamToolsLoaded();
 
 		void RequestState(void(*APIActivatedFunc)(), void(*APIShutdownFunc)());

--- a/module/sw_detours.cpp
+++ b/module/sw_detours.cpp
@@ -33,7 +33,7 @@ DETOUR_DECL_STATIC8(Hook_SteamGameServer_Init, bool, uint32, unIP, uint16, usPor
 		g_SteamTools->OnAPIActivated();
 	}
 
-	g_SteamTools->m_GameServer->RemoveHooks();
+	g_SteamTools->m_GameServer->RemoveInterfaceHooks();
 
 	return result;
 }
@@ -46,7 +46,8 @@ DETOUR_DECL_STATIC2(Hook_SteamAPI_Init_Internal, void*, LibraryHandle*, handle, 
 	{
 		g_SteamTools->m_GameServer->SetSteamClient(reinterpret_cast<ISteamClient*>(steamclient));
 		g_SteamTools->m_GameServer->SetCallbackFuncs(g_MemUtils.ResolveSymbol(*handle, "Steam_BGetCallback"), g_MemUtils.ResolveSymbol(*handle, "Steam_FreeLastCallback"));
-		g_SteamTools->m_GameServer->AddHooks();
+		g_SteamTools->m_GameServer->AddInterfaceHooks();
+		g_SteamTools->m_GameServer->AddCallbackHook();
 	}
 	else
 	{
@@ -122,15 +123,18 @@ SteamToolsGSDetours::~SteamToolsGSDetours()
 	if (m_InitGameServerDetour)
 	{
 		m_InitGameServerDetour->Destroy();
+		m_InitGameServerDetour = nullptr;
 	}
 
 	if (m_ShutdownGameServerDetour)
 	{
 		m_ShutdownGameServerDetour->Destroy();
+		m_ShutdownGameServerDetour = nullptr;
 	}
 
 	if (m_InitSteamClientDetour)
 	{
 		m_InitSteamClientDetour->Destroy();
+		m_InitSteamClientDetour = nullptr;
 	}
 }

--- a/module/sw_gameserver.h
+++ b/module/sw_gameserver.h
@@ -10,6 +10,7 @@
 #define _SW_GAMESERVER_H_
 
 #include "interfaces.h"
+#include <CDetour/detours.h>
 
 typedef HSteamUser (*GetUserFn)();
 typedef HSteamPipe (*GetPipeFn)();
@@ -38,15 +39,16 @@ class SteamToolsGameServer
 		void GetUserAndPipe(HSteamUser &hSteamUser, HSteamPipe &hSteamPipe);
 		void SetUserAndPipe(void* userFnPtr, void* pipeFnPtr);
 
-		bool GetCallback     (HSteamPipe hSteamPipe, CallbackMsg_t* pCallbackMsg);
-		void FreeLastCallback(HSteamPipe hSteamPipe);
+		void FreeLastCallback();
 		void SetCallbackFuncs(void* getFn, void* freeFn);
 
 	public:
 
-		void AddHooks();
-		void RemoveHooks();
-		void Think();
+		void AddInterfaceHooks();
+		void RemoveInterfaceHooks();
+
+		void AddCallbackHook();
+		void RemoveCallbackHook();
 
 	private:
 
@@ -66,6 +68,8 @@ class SteamToolsGameServer
 
 		GetCallbackFn      m_GetCallback;
 		FreeLastCallbackFn m_FreeLastCallback;
+
+		CDetour           *m_GetCallbackDetour;
 
 	private:
 


### PR DESCRIPTION
Fix `..\common\pipes.cpp (528) : Assertion Failed: m_OutstandingCallbackThreadId != ThreadGetCurrentId()` console spam which happens because of something Valve changed in the latest version of SteamWorks, which has been pulled in due having Steam installed on the same computer.
